### PR TITLE
Add a server and user_identifier to the user object

### DIFF
--- a/src/MastodonProvider.php
+++ b/src/MastodonProvider.php
@@ -61,9 +61,9 @@ class MastodonProvider extends AbstractProvider implements ProviderInterface
                 'Authorization' => 'Bearer ' . $token,
             ],
         ]);
-        
+
         $url_parsed = parse_url(Config::get('services.mastodon.domain'));
-        
+
         $userObject = json_decode($response->getBody(), true);
 
         return array_merge(json_decode($response->getBody(), true), [

--- a/src/MastodonProvider.php
+++ b/src/MastodonProvider.php
@@ -61,8 +61,15 @@ class MastodonProvider extends AbstractProvider implements ProviderInterface
                 'Authorization' => 'Bearer ' . $token,
             ],
         ]);
+        
+        $url_parsed = parse_url(Config::get('services.mastodon.domain'));
+        
+        $userObject = json_decode($response->getBody(), true);
 
-        return array_merge(json_decode($response->getBody(), true), ['server' => Config::get('services.mastodon.domain') ]);
+        return array_merge(json_decode($response->getBody(), true), [
+            'server' => Config::get('services.mastodon.domain'),
+            'userIdentifier' => '@' . $userObject['nickname'] . '@' . $url_parsed['host']
+        ]);
     }
 
     /**

--- a/src/MastodonProvider.php
+++ b/src/MastodonProvider.php
@@ -68,7 +68,7 @@ class MastodonProvider extends AbstractProvider implements ProviderInterface
 
         return array_merge(json_decode($response->getBody(), true), [
             'server' => Config::get('services.mastodon.domain'),
-            'userIdentifier' => '@' . $userObject['username'] . '@' . $url_parsed['host']
+            'user_identifier' => '@' . $userObject['username'] . '@' . $url_parsed['host']
         ]);
     }
 

--- a/src/MastodonProvider.php
+++ b/src/MastodonProvider.php
@@ -68,7 +68,7 @@ class MastodonProvider extends AbstractProvider implements ProviderInterface
 
         return array_merge(json_decode($response->getBody(), true), [
             'server' => Config::get('services.mastodon.domain'),
-            'userIdentifier' => '@' . $userObject['nickname'] . '@' . $url_parsed['host']
+            'userIdentifier' => '@' . $userObject['username'] . '@' . $url_parsed['host']
         ]);
     }
 

--- a/src/MastodonProvider.php
+++ b/src/MastodonProvider.php
@@ -62,7 +62,7 @@ class MastodonProvider extends AbstractProvider implements ProviderInterface
             ],
         ]);
 
-        return json_decode($response->getBody(), true);
+        return array_merge(json_decode($response->getBody(), true), ['server' => Config::get('services.mastodon.domain') ]);
     }
 
     /**


### PR DESCRIPTION
I found I needed the user in the unique federated username, so I think that adding the server and a user identifier in the @username@server_hostname format can be useful inside the application. 
Right now, my code uses the config value, but I can change it to use the value parsed from the user_object->url field if it could be useful

I am open for suggestions to fix my code if needed